### PR TITLE
Update to onEvent

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -33,7 +33,7 @@ test("onEvent called for event", async () => {
   expect(fetchMock.mock.calls[0][1]).toEqual({
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(event1),
+    body: JSON.stringify([event1]),
   });
 });
 
@@ -55,7 +55,7 @@ test("onEvent called for allowed event", async () => {
   expect(fetchMock.mock.calls[0][1]).toEqual({
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(event),
+    body: JSON.stringify([event]),
   });
 
   const event2 = createEvent({ event: "$pageLeave" });

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,63 +1,65 @@
 import {
   createEvent,
-  getMeta,
-  resetMeta,
 } from "@posthog/plugin-scaffold/test/utils";
 import fetchMock from "jest-fetch-mock";
 
 fetchMock.enableMocks();
 
-import { exportEvents } from "./index";
+import { PatternsPluginInput, onEvent, setupPlugin } from "./index";
+import { Meta } from "@posthog/plugin-scaffold";
 
 const testWebhookUrl =
   "https://api-staging.patterns.app/api/app/webhooks/wh1234";
 
 beforeEach(() => {
-  resetMeta({
-    config: {
-      webhookUrl: testWebhookUrl,
-    },
-  });
   fetchMock.resetMocks();
 });
 
-test("exportEvents called for events", async () => {
+test("onEvent called for event", async () => {
+  let meta = {
+    config: {
+      webhookUrl: testWebhookUrl,
+    },
+    global: {},
+  } as Meta<PatternsPluginInput>
+  setupPlugin(meta);
   const event1 = createEvent({ event: "$pageView" });
-  const event2 = createEvent({ event: "$pageLeave" });
 
   // @ts-ignore
-  await exportEvents([event1, event2], getMeta());
+  await onEvent(event1, meta);
 
   expect(fetchMock.mock.calls.length).toEqual(1);
-  expect(fetchMock.mock.calls[0][0]).toEqual(getMeta().config.webhookUrl);
+  expect(fetchMock.mock.calls[0][0]).toEqual(testWebhookUrl)
   expect(fetchMock.mock.calls[0][1]).toEqual({
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify([event1, event2]),
+    body: JSON.stringify(event1),
   });
 });
 
-test("exportEvents called for only allowed events", async () => {
-  resetMeta({
+test("onEvent called for allowed event", async () => {
+  let meta = {
     config: {
       webhookUrl: testWebhookUrl,
       allowedEventTypes: "$pageView, $autoCapture, $customEvent1",
     },
-  });
+    global: {},
+  } as Meta<PatternsPluginInput>
+  setupPlugin(meta);
 
-  const event1 = createEvent({ event: "$pageView" });
-  const event2 = createEvent({ event: "$pageLeave" });
-  const event3 = createEvent({ event: "$pageView" });
-  const event4 = createEvent({ event: "$autoCapture" });
-
+  const event = createEvent({ event: "$pageView" });
   // @ts-ignore
-  await exportEvents([event1, event2, event3, event4], getMeta());
-
+  await onEvent(event, meta);
   expect(fetchMock.mock.calls.length).toEqual(1);
-  expect(fetchMock.mock.calls[0][0]).toEqual(getMeta().config.webhookUrl);
+  expect(fetchMock.mock.calls[0][0]).toEqual(testWebhookUrl)
   expect(fetchMock.mock.calls[0][1]).toEqual({
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify([event1, event3, event4]),
+    body: JSON.stringify(event),
   });
+
+  const event2 = createEvent({ event: "$pageLeave" });
+  // @ts-ignore
+  await onEvent(event2, meta);
+  expect(fetchMock.mock.calls.length).toEqual(1);
 });

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,6 @@ import {
   Plugin,
   Meta,
   RetryError,
-  PluginEvent,
 } from "@posthog/plugin-scaffold";
 import fetch, { Response } from "node-fetch";
 
@@ -16,57 +15,36 @@ export interface PatternsPluginInput extends PluginInput {
   config: PatternsInputs;
 }
 
-const filterEvents = (
-  events: PluginEvent[],
-  config: PatternsInputs
-): PluginEvent[] => {
-  if (!config.allowedEventTypes) {
-    return events;
-  }
-
-  let allowedEventTypes = config.allowedEventTypes.split(",");
-  allowedEventTypes = allowedEventTypes.map((eventType) => eventType.trim());
-
-  const allowedEventTypesSet = new Set(allowedEventTypes);
-
-  let filteredEvents = events.filter((event) =>
-    allowedEventTypesSet.has(event.event)
-  );
-
-  return filteredEvents;
-};
-
 // Plugin method that runs on plugin load
 //@ts-ignore
-export async function setupPlugin({ config }: Meta<PatternsPluginInput>) {
-  console.log("Loaded Patterns app.");
+export async function setupPlugin({ config, global }: Meta<PatternsPluginInput>) {
+  if (config.allowedEventTypes) {
+    let allowedEventTypes = config.allowedEventTypes.split(",");
+    allowedEventTypes = allowedEventTypes.map((eventType: string) => eventType.trim());
+    global.allowedEventTypesSet = new Set(allowedEventTypes);
+  }
 }
 
 // Plugin method to export events
-export const exportEvents: Plugin<PatternsPluginInput>["exportEvents"] = async (
-  events: PluginEvent[],
-  { config }: Meta<PatternsPluginInput>
+export const onEvent: Plugin<PatternsPluginInput>["onEvent"] = async (
+  event,
+  { config, global }: Meta<PatternsPluginInput>
 ) => {
-  
-  let filteredEvents = filterEvents(events, config);
-  console.log(
-    `Exporting events to Patterns webhook... ${filteredEvents.length}/${events.length} events`
-  );
-  
-  if (!filteredEvents.length) {
-    return;
+  if (global.allowedEventTypesSet) {
+    if (!global.allowedEventTypesSet.has(event.event)) {
+      return
+    }
   }
   
   let response: Response;
   response = await fetch(config.webhookUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(filteredEvents),
+    body: JSON.stringify(event),
   });
 
   if (response.status != 200) {
     const data = await response.json();
     throw new RetryError(`Export events failed: ${JSON.stringify(data)}`);
   }
-  console.log("Export Success.");
 };

--- a/index.ts
+++ b/index.ts
@@ -40,7 +40,7 @@ export const onEvent: Plugin<PatternsPluginInput>["onEvent"] = async (
   response = await fetch(config.webhookUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(event),
+    body: JSON.stringify([event]),
   });
 
   if (response.status != 200) {


### PR DESCRIPTION
We're deprecating exportEvents and it's special buffer in favor of batch exports or onEvent function.

Made the plugin more efficient too - processing the input once at load time instead of for every event.
